### PR TITLE
Print migrations

### DIFF
--- a/maskpostgresdata/management/commands/dump_masked_data.py
+++ b/maskpostgresdata/management/commands/dump_masked_data.py
@@ -96,6 +96,10 @@ class Command(BaseCommand):
                     cursor.copy_to(self.stdout._out, table_name)
                     print("\\.\n", file=self.stdout._out, flush=True)
 
+        print("COPY public.django_migrations FROM stdin;".format(table_name), flush=True)
+        cursor.copy_to(self.stdout._out, 'django_migrations')
+        print("\\.\n", file=self.stdout._out, flush=True)
+
         post_data_dump = args + ["--section=post-data"]
         subprocess.run(header_dump, stdout=self.stdout._out)
 

--- a/maskpostgresdata/management/commands/dump_masked_data.py
+++ b/maskpostgresdata/management/commands/dump_masked_data.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
                     table_name = model_class._default_manager.model._meta.db_table
 
                     altered_tables.append(table_name)
-                    print("COPY public.{} FROM stdin;".format(table_name), flush=True)                
+                    print("COPY public.{} FROM stdin;".format(table_name), flush=True)
                     cursor.copy_to(self.stdout._out, table_name)
                     print("\\.\n", file=self.stdout._out, flush=True)
 
@@ -92,7 +92,7 @@ class Command(BaseCommand):
                 table_name = model._default_manager.model._meta.db_table
 
                 if table_name not in altered_tables:
-                    print("COPY public.{} FROM stdin;".format(table_name), flush=True)                
+                    print("COPY public.{} FROM stdin;".format(table_name), flush=True)
                     cursor.copy_to(self.stdout._out, table_name)
                     print("\\.\n", file=self.stdout._out, flush=True)
 


### PR DESCRIPTION
Migrations aren't part of the apps framework, so have to explicitly print them. Pretty sure that's the only table that that applies to though. Fixes #16 .

To test:

- Clone this repo and checkout this branch
- On any of our projects (django 1.8 +) pip install the local copy of this package `pip install -e ../django-maskpostgresdata`. Run `manage.py dump_masked_data`. `ctrl + f` and search for migrations and you'll see that the dump now includes the contents of the `django_migrations` table.
- If you want to be more thorough, then pipe the result of `manage.py dump_masked_data` to a file, delete the db of the project you're working on, create a new fresh db with the same name, and import the data using the dump you just created. All passwords will now be changed to `password` on the project, so run `make reset` again when you're done if you want to get back to normal.