### PR TITLE
Add default masker args for pg_dump

### DIFF
--- a/maskpostgresdata/management/commands/dump_masked_data.py
+++ b/maskpostgresdata/management/commands/dump_masked_data.py
@@ -45,6 +45,10 @@ class Command(BaseCommand):
             args += ["-p", str(port)]
         args += [dbname]
 
+        masker_args = getattr(settings, "MASKER_ARGS", ["--no-owner", "--no-privileges"])
+        if masker_args:
+            args += masker_args
+
         connection.ensure_connection()
         connection.set_autocommit(False)
 

--- a/maskpostgresdata/management/commands/dump_masked_data.py
+++ b/maskpostgresdata/management/commands/dump_masked_data.py
@@ -62,11 +62,7 @@ class Command(BaseCommand):
         header_dump = args + ["--section=pre-data"]
         subprocess.run(header_dump, stdout=self.stdout._out)
 
-        try:
-            fields_to_mask = settings.MASKER_FIELDS
-        except AttributeError:
-            fields_to_mask = None
-
+        fields_to_mask = getattr(settings, "MASKER_FIELDS")
         altered_tables = []
 
         for app in apps.get_app_configs():

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 setup(
     name='django-maskpostgresdata',
     packages=['maskpostgresdata.management'],
-    version='0.1.5',
+    version='0.1.6',
     description='Creates a pg_dumpish output which masks data without saving changes to the source database.',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Avoid having a dump with owners/privileges which a local instance of postgres is unlikely to have.