### PR TITLE
Fix missing sequences for DB dump

### DIFF
--- a/maskpostgresdata/management/commands/dump_masked_data.py
+++ b/maskpostgresdata/management/commands/dump_masked_data.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import sys
 
 from django.apps import apps
 from django.conf import settings
@@ -29,23 +28,23 @@ class Command(BaseCommand):
 
     def reset_sequences(self, cursor):
         """
-        Get all the sequances from the database and the last values for it
+        Get all the sequences from the database and the last values for it
         """
-        # Get all sequances
-        cursor.execute("SELECT * FROM information_schema.sequences;")
+        # Get all sequences
+        cursor.execute("SELECT sequence_name FROM information_schema.sequences;")
         rows = cursor.fetchall()
         for row in rows:
-            sequance_name = row[2]
+            sequence_name = row[0]
 
-            # Get the last value for the sequance
+            # Get the last value for the sequence
             cursor.execute(
-                "SELECT last_value FROM {sequance_name}".format(sequance_name=sequance_name)
+                "SELECT last_value FROM {sequence_name}".format(sequence_name=sequence_name)
             )
             last_value = cursor.fetchone()[0]
 
-            print("SELECT pg_catalog.setval('public.{sequance_name}', {last_value});".format(
-                sequance_name=sequance_name, last_value=last_value
-            ))
+            print("SELECT pg_catalog.setval('public.{sequence_name}', {last_value});".format(
+                sequence_name=sequence_name, last_value=last_value
+            ), flush=True)
 
     def handle(self, **options):
         connection = connections[options["database"]]

--- a/maskpostgresdata/management/commands/dump_masked_data.py
+++ b/maskpostgresdata/management/commands/dump_masked_data.py
@@ -125,7 +125,7 @@ class Command(BaseCommand):
         cursor.copy_to(self.stdout._out, 'django_migrations')
         print("\\.\n", file=self.stdout._out, flush=True)
 
-        # Sets a new values for sequances.
+        # Sets a new values for sequences.
         self.reset_sequences(cursor)
 
         post_data_dump = args + ["--section=post-data"]

--- a/maskpostgresdata/management/commands/dump_masked_data.py
+++ b/maskpostgresdata/management/commands/dump_masked_data.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
     def update_auth_user(self, queryset):
         queryset.update(password=make_password("password"))
 
-    def reset_sequence(self, cursor):
+    def reset_sequences(self, cursor):
         """
         Get all the sequances from the database and the last values for it
         """
@@ -127,7 +127,7 @@ class Command(BaseCommand):
         print("\\.\n", file=self.stdout._out, flush=True)
 
         # Sets a new values for sequances.
-        self.reset_sequence(cursor)
+        self.reset_sequences(cursor)
 
         post_data_dump = args + ["--section=post-data"]
         subprocess.run(post_data_dump, stdout=self.stdout._out, env=subprocess_env)

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,11 @@ with open('README.md') as f:
 setup(
     name='django-maskpostgresdata',
     packages=find_packages(),
-    version='0.1.8',
-    description='Creates a pg_dumpish output which masks data without saving changes to the source database.',
+    version='0.1.9',
+    description=(
+        'Creates a pg_dumpish output which masks data without saving changes to the source '
+        'database.',
+    ),
     long_description=long_description,
     long_description_content_type="text/markdown",
     url='https://github.com/developersociety/django-maskpostgresdata',
@@ -15,5 +18,5 @@ setup(
     author_email='hello@dev.ngo',
     license='BSD',
     zip_safe=False,
-    install_requires = ['django>=1.8','psycopg2']
+    install_requires=['django>=1.8', 'psycopg2']
 )


### PR DESCRIPTION
https://favro.com/organization/b03d6d6d9b11b61167ac4246/418c53a770389640d415a230?card=Dev-14026

Testing:

1. Use `devsoc` repository
2. Install `django-maskpostgresdata` with command `pip install -e git+git@github.com:developersociety/django-maskpostgresdata@fix-sequancesr#egg=maskpostgresdata`
3. Get a fresh back for the devsoc by amending `fabfile` to use the old way of getting a backup.
4. Run `./manage.py dump_masked_data  > data.dump`
5. Restore database
6. Check to see if sequences match the live database `SELECT last_value FROM django_migrations_id_seq;` etc..