### PR TITLE
Version bump and postgres binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 setup(
     name='django-maskpostgresdata',
     packages=find_packages(),
-    version='0.1.9',
+    version='0.10',
     description=(
         'Creates a pg_dumpish output which masks data without saving changes to the source '
         'database.'
@@ -18,5 +18,5 @@ setup(
     author_email='hello@dev.ngo',
     license='BSD',
     zip_safe=False,
-    install_requires=['django>=1.8', 'psycopg2']
+    install_requires=['django>=1.8', 'psycopg2-binary']
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 setup(
     name='django-maskpostgresdata',
     packages=find_packages(),
-    version='0.10',
+    version='0.1.10',
     description=(
         'Creates a pg_dumpish output which masks data without saving changes to the source '
         'database.'


### PR DESCRIPTION
**Sources**

https://app.forecast.it/T362 (related to this card but nothing in this card describing this issue)

**Description**

Changes `psycopg2` to `psycopg2-binary` so that this package doesn't break the serverless deployment of projects to AWS lambda.

**To test**

If you've got AWS vault set up and you want to test the specific issue that this resolves for me.

- Clone the `devsoc` repo
- Check out the `yougetacar` branch
- Uncomment `# maskpostgresdata` in `INSTALLED_APPS` in base settings
- Change line 11 in `requirements/base.txt` to `
git+git://github.com/developersociety/django-maskpostgresdata@psycopg2binary#egg=django-maskpostgresdata`
- Run `fab demo_deploy` 

If you just want to test that this hasn't broken everything and trust me that the previous part works 😛

- Clone the `devsoc` repo
- Change line 11 in `requirements/base.txt` to `
git+git://github.com/developersociety/django-maskpostgresdata@psycopg2binary#egg=django-maskpostgresdata`
- Run `./manage.py dump_masked_data` and check nothing breaks.