### PR TITLE
Don't dump geodjango tables, drop psycopg2-binary dependency

### DIFF
--- a/maskpostgresdata/management/commands/dump_masked_data.py
+++ b/maskpostgresdata/management/commands/dump_masked_data.py
@@ -121,6 +121,10 @@ class Command(BaseCommand):
                     print("\\.\n", file=self.stdout._out, flush=True)
 
         for app in apps.get_app_configs():
+            # GeoDjango tables are automatically created by postgis, and we can't use COPY on them
+            if app.name == "django.contrib.gis":
+                continue
+
             for model in app.get_models():
                 table_name = model._default_manager.model._meta.db_table
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 setup(
     name='django-maskpostgresdata',
     packages=find_packages(),
-    version='0.1.11',
+    version='0.1.12',
     description=(
         'Creates a pg_dumpish output which masks data without saving changes to the source '
         'database.'

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
     author_email='hello@dev.ngo',
     license='BSD',
     zip_safe=False,
-    install_requires=['django>=1.8', 'psycopg2-binary']
+    install_requires=['django>=1.8']
 )


### PR DESCRIPTION
https://app.forecast.it/project/P-31/scoping/T548

Two things for this:

- Drop the psycopg2 dependency (see the commit message for full details)
- Make this app work for projects with GeoDjango!

To test:

Add to a geodjango project locally:

```
pip install -e git+ssh://git@github.com/developersociety/django-maskpostgresdata.git@geodjango-binary#egg=django-maskpostgresdata
```

Add ` "maskpostgresdata",` to `THIRD_PARTY_APPS`

```
./manage.py dump_masked_data > dump.sql
dropdb projectname_django
createdb projectname_django
psql -1 -f dump.sql projectname_django
```