### PR TITLE
Fix to be able to import m2m tables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 setup(
     name='django-maskpostgresdata',
     packages=find_packages(),
-    version='0.1.12',
+    version='0.1.13',
     description=(
         'Creates a pg_dumpish output which masks data without saving changes to the source '
         'database.'


### PR DESCRIPTION
## Source 
https://app.forecast.it/project/P-17/scoping/T2388

## How to test
1. Use `ahs` repo as testing one
2. `pip install -e git+ssh://git@github.com/developersociety/django-maskpostgresdata.git@m2m-tables#egg=django-maskpostgresdata`
2. `fab get_backup`
3. Go to `http://localhost:8000/admin/login/?next=/admin/pages/23/edit/`
4. Check `Antiquarian Horology` and save the page
5. `./manage.py dump_masked_data > dump.sql`
6. `dropdb ahs_django`
7.  `createdb ahs_django`
8. `psql -1 -f dump.sql ahs_django`

After recreating database go to http://localhost:8000/admin/pages/23/edit/ and you should see the check on the `Antiquarian Horology`