### PR TITLE
Use a separate path for BrokenPipeError

### DIFF
--- a/maskpostgresdata/management/commands/dump_masked_data.py
+++ b/maskpostgresdata/management/commands/dump_masked_data.py
@@ -52,9 +52,13 @@ class Command(BaseCommand):
     def handle(self, **options):
         try:
             self.process_data(**options)
-        except (KeyboardInterrupt, BrokenPipeError):
+        except KeyboardInterrupt:
             print("\n", file=self.stdout._out, flush=True)
             print("Keyboard interaction detected", file=self.stdout._out, flush=True)
+            sys.exit(0)
+        except BrokenPipeError:
+            # Usually the result of a connection drop during the command - there's no point in
+            # printing any response, as that's the cause of the problem!
             sys.exit(0)
 
     def process_data(self, **options):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 setup(
     name='django-maskpostgresdata',
     packages=find_packages(),
-    version='0.1.13',
+    version='0.1.14',
     description=(
         'Creates a pg_dumpish output which masks data without saving changes to the source '
         'database.'


### PR DESCRIPTION
I realised that we added a try/except ages ago, however if we're trying to print to a dropped connection - that's also not a good idea!