### PR TITLE
Don't export proxy models

### DIFF
--- a/maskpostgresdata/management/commands/dump_masked_data.py
+++ b/maskpostgresdata/management/commands/dump_masked_data.py
@@ -139,6 +139,10 @@ class Command(BaseCommand):
                 continue
 
             for model in app.get_models():
+                if model._meta.proxy:
+                    # Proxy models have another underlying model/table - so skip
+                    continue
+
                 table_name = model._default_manager.model._meta.db_table
 
                 if table_name not in altered_tables:


### PR DESCRIPTION
Proxy models are repeats of existing models in the project, which resulted in the same table being exported twice.

To test:

- Do a `make clear` on acts435 - I've added these 3 lines server side to make it easier to test