### PR TITLE
🎃 Fix requires_system_checks for Django 4.1

### DIFF
--- a/maskpostgresdata/management/commands/dump_masked_data.py
+++ b/maskpostgresdata/management/commands/dump_masked_data.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 
+import django
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
@@ -14,7 +15,7 @@ from psycopg2.extensions import ISOLATION_LEVEL_SERIALIZABLE
 class Command(BaseCommand):
     help = "Prints a (sort of) pg_dump of the db with sensitive data masked."
 
-    requires_system_checks = False
+    requires_system_checks = [] if django.VERSION >= (3, 2) else False
 
     def add_arguments(self, parser):
         parser.add_argument(


### PR DESCRIPTION
This was changed to use a list in Django 3.2, and backwards compatibility changed in Django 4.1:

- https://docs.djangoproject.com/en/3.2/releases/3.2/#management-commands
- https://docs.djangoproject.com/en/4.1/releases/4.1/#features-removed-in-4-1

To test:

- Try this on devsoc
- `pip install -e git+ssh://git@github.com/developersociety/django-maskpostgresdata.git@django-4.1#egg=django-maskpostgresdata`
- `./manage.py dump_masked_data`

Should no longer error out.