### PR TITLE
Fix m2m through models from being dumped twice

### DIFF
--- a/maskpostgresdata/management/commands/dump_masked_data.py
+++ b/maskpostgresdata/management/commands/dump_masked_data.py
@@ -146,7 +146,7 @@ class Command(BaseCommand):
 
                 table_name = model._default_manager.model._meta.db_table
 
-                if table_name not in altered_tables:
+                if table_name not in altered_tables and table_name not in copied_tables:
                     print("COPY public.{} FROM stdin;".format(table_name), flush=True)
                     cursor.copy_to(self.stdout._out, table_name)
                     print("\\.\n", file=self.stdout._out, flush=True)


### PR DESCRIPTION
First time this has happened, most likely as the model on this project is using a `through=` for the many to many relationship.

To test: `make clear` on the impacted project - I've temporarily done a manual edit on the project so it'll work.