### PR TITLE
Django 4.2 / psycopg v3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,8 @@ setup(
     author_email='hello@dev.ngo',
     license='BSD',
     zip_safe=False,
-    install_requires=['django>=4.2']
+    install_requires=[
+        'django>=4.2',
+        'psycopg>=3.1.8',
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
     author_email='hello@dev.ngo',
     license='BSD',
     zip_safe=False,
-    install_requires=['django>=1.8']
+    install_requires=['django>=4.2']
 )


### PR DESCRIPTION
So, this is probably one of our weakest packages (has no tests, lacks our standard tooling), and I'd like to do a version 2 at some point - however we need a version which supports Django 4.2 / psycopg v3 earlier than that.

To test: try `make clear` on devsentry - I've manually edited the file to match this PR.

The plan is to release this as 0.2, and any bug fixes needed for the old version can be in a stable/0.1 branch.